### PR TITLE
Fix QNX build

### DIFF
--- a/build-aux/config.sub
+++ b/build-aux/config.sub
@@ -2,7 +2,7 @@
 # Configuration validation subroutine script.
 #   Copyright 1992-2020 Free Software Foundation, Inc.
 
-timestamp='2020-08-17'
+timestamp='2020-09-05'
 
 # This file is free software; you can redistribute it and/or modify it
 # under the terms of the GNU General Public License as published by
@@ -1367,13 +1367,7 @@ case $os in
 		os=psos
 		;;
 	qnx*)
-		case $cpu in
-		    x86 | i*86)
-			;;
-		    *)
-			os=nto-$os
-			;;
-		esac
+		os=qnx
 		;;
 	hiux*)
 		os=hiuxwe2
@@ -1722,7 +1716,7 @@ case $os in
 	     | skyos* | haiku* | rdos* | toppers* | drops* | es* \
 	     | onefs* | tirtos* | phoenix* | fuchsia* | redox* | bme* \
 	     | midnightbsd* | amdhsa* | unleashed* | emscripten* | wasi* \
-	     | nsk* | powerunix* | genode* | zvmoe* )
+	     | nsk* | powerunix* | genode* | zvmoe* | qnx* )
 		;;
 	# This one is extra strict with allowed versions
 	sco3.2v2 | sco3.2v[4-9]* | sco5v6*)

--- a/configure.ac
+++ b/configure.ac
@@ -787,9 +787,7 @@ case "${canonical}" in
     opsys=qnxnto
     test -z "$CC" && CC=qcc
     CFLAGS="$CFLAGS -D__NO_EXT_QNX"
-    if test "$with_unexec" = yes; then
-      LDFLAGS="-N2MB $LDFLAGS"
-    fi
+    LDFLAGS="-N2M $LDFLAGS"
   ;;
 
   ## Intel 386 machines where we don't care about the manufacturer.
@@ -2825,7 +2823,14 @@ PGTK_OBJ=
 PGTK_LIBS=
 if test "$window_system" = "pgtk"; then
   PGTK_OBJ="pgtkfns.o pgtkterm.o pgtkselect.o pgtkmenu.o pgtkim.o xsettings.o"
-  PGTK_LIBS="$GTK_LIBS -ldl"
+  PGTK_LIBS="$GTK_LIBS"
+  case $opsys in
+    gnu|gnu-linux)
+      PGTK_LIBS="$PGTK_LIBS -ldl"
+      ;;
+    *)
+      ;;
+  esac
   HAVE_PGTK=yes
   AC_DEFINE([HAVE_PGTK], 1, [Define to 1 if you have pure Gtk+-3.])
 fi


### PR DESCRIPTION
1. config.sub fails to recognize modern QNX systems.
2. The link flag for increasing the main stack size is wrong, and should also not be conditional (emacs switched the default dump method).
3. -ldl is not needed for dlopen() et al (though typically configure would have a rule to detect that).